### PR TITLE
Fix line breaks that cause tabs in input fields in Unraid UI

### DIFF
--- a/OctoPrint/OctoPrint.xml
+++ b/OctoPrint/OctoPrint.xml
@@ -66,35 +66,7 @@
 	</Data>
 	<Environment/>
 	<Labels/>
-	<Config 
-		Name="config"
-		Target="/home/octoprint"
-		Default="/mnt/user/appdata/octoprint"
-		Mode="rw"
-		Description="Container Path: /home/octoprint"
-		Type="Path" Display="always"
-		Required="true" Mask="false">/mnt/user/appdata/octoprint
-	</Config>
-	<Config
-		Name="WebUI"
-		Target="5000"
-		Default="5000"
-		Mode="tcp"
-		Description="Container Port: 5000"
-		Type="Port"
-		Display="always"
-		Required="true"
-		Mask="false">5000
-	</Config>
-	<Config
-		Name="Printer USB Port"
-		Target=""
-		Default="/dev/ttyACM0"
-		Mode=""
-		Description="Container Device: "
-		Type="Device"
-		Display="always"
-		Required="true"
-		Mask="false">/dev/ttyACM0
-	</Config>
+	<Config Name="config" Target="/home/octoprint" Default="/mnt/user/appdata/octoprint" Mode="rw" Description="Container Path: /home/octoprint" Type="Path" Display="always" Required="true" Mask="false">/mnt/user/appdata/octoprint</Config>
+	<Config	Name="WebUI" Target="5000" Default="5000" Mode="tcp" Description="Container Port: 5000" Type="Port" Display="always" Required="true" Mask="false">5000</Config>
+	<Config Name="Printer USB Port" Target="" Default="/dev/ttyACM0" Mode="" Description="Container Device: " Type="Device" Display="always" Required="true" Mask="false">/dev/ttyACM0</Config>
 </Container>

--- a/OctoPrint/OctoPrint.xml
+++ b/OctoPrint/OctoPrint.xml
@@ -68,5 +68,5 @@
 	<Labels/>
 	<Config Name="config" Target="/home/octoprint" Default="/mnt/user/appdata/octoprint" Mode="rw" Description="Container Path: /home/octoprint" Type="Path" Display="always" Required="true" Mask="false">/mnt/user/appdata/octoprint</Config>
 	<Config	Name="WebUI" Target="5000" Default="5000" Mode="tcp" Description="Container Port: 5000" Type="Port" Display="always" Required="true" Mask="false">5000</Config>
-	<Config Name="Printer USB Port" Target="" Default="/dev/ttyACM0" Mode="" Description="Container Device: " Type="Device" Display="always" Required="true" Mask="false">/dev/ttyACM0</Config>
+	<Config Name="Printer USB Port" Target="" Default="/dev/ttyACM0" Mode="" Description="Container Device: /dev/ttyACM0" Type="Device" Display="always" Required="true" Mask="false">/dev/ttyACM0</Config>
 </Container>


### PR DESCRIPTION
If you don't adjust the input fields within Unraid, you'll get a appdata folder that is created with a name of "/mnt/user/appdata/octoprint\t".

It doesn't appear to like the use line breaks within the formatting of Config